### PR TITLE
Initial commit for branch "dev_check_censusAPIkey" (ndi v0.1.4.9000)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ndi
 Title: Neighborhood Deprivation Indices
-Version: 0.1.3
-Date: 2022-12-01
+Version: 0.1.4.9000
+Date: 2022-12-02
 Authors@R:
     c(person(given = "Ian D.",
              family = "Buller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # ndi (development version)
 
+# ndi v0.1.4.9000
+
+### New Features
+* None
+
+### Updates
+* Fixed bug in reverse dependency check failure for `anthopolos()` and `bravo()` functions removing `returnValue()` when data are not missing
+* Thank you, [Roger Bivand](https://github.com/rsbivand), for the catch. Relates to [ndi Issue #5](https://github.com/idblr/ndi/issues/5)
+* Updated `duncan()`, `gini()`, `krieger()`, `messer()`, and `powell_wiley()` for consistency in messaging when data are not missing
+* Updated tests for `anthopolos()` and `bravo()` if `Sys.getenv("CENSUS_API_KEY") != ""`
+
 # ndi v0.1.3
 
 ### New Features

--- a/R/anthopolos.R
+++ b/R/anthopolos.R
@@ -174,8 +174,6 @@ anthopolos <- function(geo = "tract", year = 2020, subgroup, quiet = FALSE, ...)
     # Warning for missing census data
     if (sum(missingYN$n_missing) > 0) {
       message("Warning: Missing census data")
-    } else {
-      returnValue(missingYN)
     }
   }
   

--- a/R/bravo.R
+++ b/R/bravo.R
@@ -182,8 +182,6 @@ bravo <- function(geo = "tract", year = 2020, subgroup, quiet = FALSE, ...) {
     # Warning for missing census data
     if (sum(missingYN$n_missing) > 0) {
       message("Warning: Missing census data")
-    } else {
-      returnValue(missingYN)
     }
   }
   

--- a/R/duncan.R
+++ b/R/duncan.R
@@ -211,8 +211,6 @@ duncan <- function(geo_large = "county", geo_small = "tract", year = 2020, subgr
     # Warning for missing census data
     if (sum(missingYN$n_missing) > 0) {
       message("Warning: Missing census data")
-    } else {
-      returnValue(missingYN)
     }
   }
 

--- a/R/gini.R
+++ b/R/gini.R
@@ -83,8 +83,6 @@ gini <- function(geo = "tract", year = 2020, quiet = FALSE, ...) {
     # Warning for missing census data
     if (sum(missingYN$n_missing) > 0) {
       message("Warning: Missing census data")
-    } else {
-      returnValue(missingYN)
     }
   }
   

--- a/R/krieger.R
+++ b/R/krieger.R
@@ -259,8 +259,6 @@ krieger <- function(geo = "tract", year = 2020, quiet = FALSE, ...) {
     # Warning for missing census data
     if (sum(missingYN$n_missing) > 0) {
       message("Warning: Missing census data")
-    } else {
-      returnValue(missingYN)
     }
   }
   

--- a/R/messer.R
+++ b/R/messer.R
@@ -211,10 +211,8 @@ messer <- function(geo = "tract", year = 2020, imp = FALSE, quiet = FALSE, round
   
   if (quiet == FALSE) {
     # Warning for missing census data
-    if (sum(missingYN$n_missing) > 0) {
-      message("Warning: Missing census data")
-    } else {
-      returnValue(missingYN)
+    if (sum(missingYN$n_missing) > 0) { 
+      message("Warning: Missing census data") 
     }
     
     # Warning for proportion of variance explained by PC1

--- a/R/powell_wiley.R
+++ b/R/powell_wiley.R
@@ -274,8 +274,6 @@ powell_wiley <- function(geo = "tract", year = 2020, imp = FALSE, quiet = FALSE,
     # Warning for missing census data
     if (sum(missingYN$n_missing) > 0) {
       message("Warning: Missing census data")
-    } else {
-      returnValue(missingYN)
     }
     
     # Warning for Cronbach's alpha < 0.7

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ndi: Neighborhood Deprivation Indices <img src="man/figures/ndi.png" width="120"
 [![DOI](https://zenodo.org/badge/521439746.svg)](https://zenodo.org/badge/latestdoi/521439746)
 <!-- badges: end -->
 
-**Date repository last updated**: December 01, 2022
+**Date repository last updated**: December 02, 2022
 
 ### Overview
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,15 +1,10 @@
-## This is the fourth resubmission
+## This is the fifth resubmission
 
 * Actions taken since previous submission:
-  * Added `duncan()` function to compute the Dissimilarity Index (DI) based on [Duncan & Duncan (1955)](https://doi.org/10.2307/2088328) for specified counties/tracts 2009 onward.
-  * Fixed bug in `bravo()` function where ACS-5 data (2005-2009) are from the "B15002" question and "B06009" after
-  * Fixed bug in missingness warning for all metrics
-  * `utils` is now Imports
-  * Updated vignette and README with new features
-  * Updated Description in DESCRIPTION
-  * Updated tests
-  * Updated CITATION with new citation for the additional metric
-  * Updated maintainer contact information
+  * Fixed bug in reverse dependency check failure for `anthopolos()` and `bravo()` functions removing `returnValue()` when data are not missing
+  * Thank you, [Roger Bivand](https://github.com/rsbivand), for the catch. Relates to [ndi Issue #5](https://github.com/idblr/ndi/issues/5)
+  * Updated `duncan()`, `gini()`, `krieger()`, `messer()`, and `powell_wiley()` for consistency in messaging when data are not missing
+  * Updated tests for `anthopolos()` and `bravo()` if `Sys.getenv("CENSUS_API_KEY") != ""`
 
 * Documentation for DESCRIPTION, README, NEWS, and vignette references the following DOIs, which throws a NOTE but are a valid URL:
   * <https://doi.org/10.1111/j.1749-6632.2009.05333.x>

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -5,7 +5,7 @@ citEntry(entry = "manual",
   author        = personList(as.person("Ian D. Buller")),
   publisher     = "The Comprehensive R Archive Network",
   year          = "2022",
-  number        = "0.1.3",
+  number        = "0.1.4.9000",
   doi           = "10.5281/zenodo.6989030",
   url           = "https://cran.r-project.org/package=ndi",
   
@@ -13,7 +13,7 @@ citEntry(entry = "manual",
   paste("Ian D. Buller (2022).",
         "ndi: Neighborhood Deprivation Indices.",
         "The Comprehensive R Archive Network.",
-        "v0.1.3.",
+        "v0.1.4.9000.",
         "DOI:10.5281/zenodo.6989030",
         "Accessed by: https://cran.r-project.org/package=ndi")
 )

--- a/tests/testthat/test-anthopolos.R
+++ b/tests/testthat/test-anthopolos.R
@@ -27,7 +27,7 @@ test_that("anthopolos works", {
   
   skip_if(Sys.getenv("CENSUS_API_KEY") == "")
   
-  expect_silent(anthopolos(state = "DC", year = 2020, subgroup = c("NHoLB", "HoLB"))) 
+  expect_output(anthopolos(state = "DC", year = 2020, subgroup = c("NHoLB", "HoLB"))) 
   
   expect_silent(anthopolos(state = "DC", year = 2020, subgroup = "NHoLB", quiet = TRUE))
   

--- a/tests/testthat/test-bravo.R
+++ b/tests/testthat/test-bravo.R
@@ -27,9 +27,7 @@ test_that("bravo works", {
   
   skip_if(Sys.getenv("CENSUS_API_KEY") == "")
   
-  expect_silent(bravo(state = "DC", year = 2009, subgroup = c("LtHS", "HSGiE"))) 
-  
-  expect_silent(bravo(state = "DC", year = 2020, subgroup = c("LtHS", "HSGiE"))) 
+  expect_output(bravo(state = "DC", year = 2009, subgroup = c("LtHS", "HSGiE")))
   
   expect_silent(bravo(state = "DC", year = 2020, subgroup = "LtHS", quiet = TRUE))
   


### PR DESCRIPTION
* Fixed bug in reverse dependency check failure for `anthopolos()` and `bravo()` functions removing `returnValue()` when data are not missing
  * Thank you, [Roger Bivand](https://github.com/rsbivand), for the catch. Relates to [ndi Issue #5](https://github.com/idblr/ndi/issues/5)
  * Updated `duncan()`, `gini()`, `krieger()`, `messer()`, and `powell_wiley()` for consistency in messaging when data are not missing
  * Updated tests for `anthopolos()` and `bravo()` if `Sys.getenv("CENSUS_API_KEY") != ""`