### PR TITLE
Fix faulty join args

### DIFF
--- a/R/powell_wiley.R
+++ b/R/powell_wiley.R
@@ -249,7 +249,7 @@ powell_wiley <- function(geo = "tract", year = 2020, imp = FALSE, quiet = FALSE,
   ndi_vars_NA <- ndi_vars[complete.cases(ndi_vars_scrs), ]
   ndi_vars_NA$NDI <- c(scrs)
   
-  ndi_vars_NDI <- dplyr::left_join(ndi_vars[ , c("GEOID", "TotalPop")], ndi_vars_NA[ , c("GEOID", "NDI")], by = "GEOID", all.x = TRUE)
+  ndi_vars_NDI <- dplyr::left_join(ndi_vars[ , c("GEOID", "TotalPop")], ndi_vars_NA[ , c("GEOID", "NDI")], by = "GEOID")
   
   # Calculate Cronbach's alpha correlation coefficient among the factors and verify values are above 0.7. 
   if (nfa == 1) { 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ ggplot2::ggplot() +
 # --------------------------- #
 
 # Merge the two NDI metrics (Messer and Powell-Wiley, imputed)
-ndi2020DC <- dplyr::left_join(messer2020DC$ndi, powell_wiley2020DCi$ndi, by = "GEOID", suffixes = c(".messer", ".powell_wiley"))
+ndi2020DC <- dplyr::left_join(messer2020DC$ndi, powell_wiley2020DCi$ndi, by = "GEOID", suffix = c(".messer", ".powell_wiley"))
 
 # Check the correlation the two NDI metrics (Messer and Powell-Wiley, imputed) as continuous values
 cor(ndi2020DC$NDI.messer, ndi2020DC$NDI.powell_wiley, use = "complete.obs") # Pearsons r = 0.975


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`left_join()` now checks `...` for any misspecified arguments. You supplied `all.x` which is not an argument to `left_join()`.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!