### PR TITLE
Dev pw

### DIFF
--- a/R/powell_wiley.R
+++ b/R/powell_wiley.R
@@ -49,10 +49,11 @@
 #' @import dplyr
 #' @importFrom MASS ginv
 #' @importFrom psych alpha principal
-#' @importFrom stats complete.cases cor cov2cor loadings median promax quantile sd
+#' @importFrom stats complete.cases cor cov2cor loadings median promax sd
 #' @importFrom stringr str_trim
 #' @importFrom tidycensus get_acs
 #' @importFrom tidyr pivot_longer separate
+#' @importFrom wtd quantile
 #' @export
 #'
 #' @seealso \code{\link[tidycensus]{get_acs}} for additional arguments for geographic referent selection (i.e., \code{state} and \code{county}).
@@ -346,9 +347,10 @@ powell_wiley <- function(geo = 'tract',
   NDIQuint <- ndi_data_NDI %>%
     dplyr::mutate(
       NDIQuint = cut(
-        NDI * log(TotalPop),
-        breaks = stats::quantile(
-          NDI * log(TotalPop),
+        NDI,
+        breaks = wtd::quantile(
+          NDI,
+          weights = TotalPop,
           probs = c(0, 0.2, 0.4, 0.6, 0.8, 1),
           na.rm = TRUE
         ),

--- a/R/powell_wiley.R
+++ b/R/powell_wiley.R
@@ -53,7 +53,7 @@
 #' @importFrom stringr str_trim
 #' @importFrom tidycensus get_acs
 #' @importFrom tidyr pivot_longer separate
-#' @importFrom wtd quantile
+#' @importFrom Hmisc wtd.quantile
 #' @export
 #'
 #' @seealso \code{\link[tidycensus]{get_acs}} for additional arguments for geographic referent selection (i.e., \code{state} and \code{county}).
@@ -348,7 +348,7 @@ powell_wiley <- function(geo = 'tract',
     dplyr::mutate(
       NDIQuint = cut(
         NDI,
-        breaks = wtd::quantile(
+        breaks = Hmisc::wtd.quantile(
           NDI,
           weights = TotalPop,
           probs = c(0, 0.2, 0.4, 0.6, 0.8, 1),


### PR DESCRIPTION
Andrews et al. (2020) and Slotman et al. (2022) were not very descriptive about the method used to "Population weighted NDI quintiles."

As currently implemented, Quintile cutoffs are determined by the product of the calculated NDI, and the logarithmic transform of the Total Population.

This does yield similar quintile results as the NDIQuint provided by Slotman et al. (2022) when rederiving NDIQuint using the provided NDI values joined with ACS5 Total_Population (B01001_001), but there are some discrepancies. See below:

![current](https://github.com/user-attachments/assets/67a63cd0-8bd7-40c0-b8a4-c676a85f97f6)

Another definition would be to use a weighted quantile function, were the values are NDI, and weights are ACS5 Total_Population. I.E. distribute the NDI to each person in the tract and determine cutoffs for the entire population. Below is the comparison of this method and NDIQuint provided by Slotman et al. (2022):

![proposed](https://github.com/user-attachments/assets/e6c3541f-487a-4b1d-80e9-25b1ffac9e12)

This is a relatively minor change, feel free to disagree/reject. I am a python developer, and am unable to fully test the build (Ex roxygen2). I also did not see a appropriate dev branch to fork from.